### PR TITLE
Add dependabot configuration file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+- package-ecosystem: nuget
+  directory: "/"
+  schedule:
+    interval: monthly
+    time: "00:00"
+  open-pull-requests-limit: 10
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    # Check for updates to GitHub Actions every weekday
+    interval: "monthly"  


### PR DESCRIPTION
Add Dependabot configuration file for both NuGet packages and GitHub actions. 

Configured to run monthly. 

https://github.com/rubicon-oss/CoreRhinoMocks/network/updates can be used to also run manually once activated 

Fixes #8 